### PR TITLE
miny: Don't deallocate ZSTs

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -68,3 +68,11 @@ fn with_zst() {
 	assert!(Miny::into_box(fake).is::<()>());
 	assert_eq!(Miny::into_box(real), Box::new(()));
 }
+
+#[test]
+fn zst_from_box() {
+	let boxed = Box::new(());
+	let min = core::hint::black_box(Miny::from(boxed));
+	// Should not dealloc
+	drop(min);
+}


### PR DESCRIPTION
`Box<ZST>` is just a dangling pointer. So we should not deallocate it during `From<Box<ZST>>::from`.

The test case failed previously, depending on your malloc, with a message like this:

```
miny-52ad587ee1bf78f4(32531,0x1708f3000) malloc: *** error for object 0x1: pointer being freed was not allocated
ok
miny-52ad587ee1bf78f4(32531,0x1708f3000) malloc: *** set a breakpoint in malloc_error_break to debug
```

As a side note, I absolutely love this crate, and I went looking for something I could fix just so I could say so. It's so perfect for use in [incremental](https://github.com/cormacrelf/incremental-rs) (upcoming changes to type-erase everything), that I think I will add a nightly feature to swap out Box for Miny. `Miny<dyn Any>` is basically V8's NaN-tagged pointers or OCaml's 63-bit integers, but makes this available for every T. Just devastatingly effective. Thank you!

I actually started writing my own version of Miny before I discovered yours, and it was extremely similar (with an identical `size_of <= usize, align_of <= usize` function) up until I couldn't put trait objects in there on stable. My code did have an extra feature, which might be interesting -- a const parameter that adds extra bytes of inline space beyond one pointer's worth.