### PR TITLE
Make `just-kdl` crate `no_std`

### DIFF
--- a/just-kdl/Cargo.toml
+++ b/just-kdl/Cargo.toml
@@ -12,9 +12,16 @@ documentation = "https://docs.rs/just-kdl"
 homepage = "https://github.com/1e1001/rsutil/tree/main/just-kdl"
 repository = "https://github.com/1e1001/rsutil/tree/main/just-kdl"
 
+[dependencies]
+hashbrown = "0.16.0"
+
 [dependencies.thiserror]
 version = "2.0.11"
 
 # for testing compliance & performance
 [dev-dependencies.kdl]
 version = "6.3.4"
+
+[features]
+default = ["std"]
+std = []

--- a/just-kdl/src/dom.rs
+++ b/just-kdl/src/dom.rs
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! document tree structures, start at [`Document`]
 
-use std::borrow::Cow;
-use std::cell::Cell;
-use std::collections::HashSet;
-use std::convert::Infallible;
-use std::fmt;
-use std::ops::{Index, IndexMut};
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cell::Cell;
+use core::convert::Infallible;
+use core::fmt;
+use core::ops::{Index, IndexMut};
+
+use hashbrown::HashSet;
 
 use crate::number::Number;
 use crate::stream::{Error, Event, Parser};
@@ -174,17 +178,18 @@ impl<'text> Node<'text> {
 		let mut seen = HashSet::new();
 		for entry in self.entries.iter_mut().rev() {
 			if let Some(key) = &mut entry.key {
-				if seen.contains(key) {
+				if seen.contains(&**key) {
 					*key = Cow::Borrowed(marker);
 				} else {
-					seen.insert(&*key);
+					seen.insert(&**key);
 				}
 			}
 		}
+		drop(seen);
 		self.entries.retain(|ent| {
 			!ent.key
 				.as_ref()
-				.is_some_and(|key| std::ptr::eq(key.as_ptr(), marker.as_ptr()) && key.is_empty())
+				.is_some_and(|key| core::ptr::eq(key.as_ptr(), marker.as_ptr()) && key.is_empty())
 		});
 	}
 }

--- a/just-kdl/src/lib.rs
+++ b/just-kdl/src/lib.rs
@@ -42,9 +42,12 @@
 //!
 //! [kdl]: <https://kdl.dev>
 //! [kdl-rs]: https://docs.rs/kdl
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 
-use std::borrow::Cow;
-use std::fmt;
+extern crate alloc;
+
+use alloc::borrow::{Cow, ToOwned};
+use core::fmt;
 
 pub mod dom;
 pub mod number;

--- a/just-kdl/src/number.rs
+++ b/just-kdl/src/number.rs
@@ -3,10 +3,10 @@
 //!
 //! This is a similar approach as used in other serialization libraries I found
 
-use std::fmt;
-use std::mem::discriminant;
-use std::num::FpCategory;
-use std::str::FromStr;
+use core::fmt;
+use core::mem::discriminant;
+use core::num::FpCategory;
+use core::str::FromStr;
 
 use thiserror::Error;
 
@@ -48,8 +48,8 @@ impl PartialEq for NumberInner {
 	}
 }
 impl Eq for NumberInner {}
-impl std::hash::Hash for NumberInner {
-	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl core::hash::Hash for NumberInner {
+	fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
 		discriminant(self).hash(state);
 		match *self {
 			NumberInner::Float(v) => norm_float(v).hash(state),

--- a/just-kdl/src/stream.rs
+++ b/just-kdl/src/stream.rs
@@ -12,8 +12,10 @@
 // TODO: some alternative input api: peek/consume utf-8 stream?
 // TODO: fuzzing!
 
-use std::borrow::Cow;
-use std::fmt;
+use alloc::borrow::{Cow, ToOwned};
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
 
 use crate::dom::Value;
 use crate::number::{Number, NumberError};
@@ -538,7 +540,7 @@ impl<'text> Grammar<'text> {
 				}
 			})
 			.collect::<PResult<Vec<_>>>()
-			.map(|lines| dbg!(lines).join("\n"))
+			.map(|lines| lines.join("\n"))
 	}
 	/// {single, multi}-line {raw, escaped} string, starting after the first "
 	fn quoted_string(&self, start: Pos, raw: usize) -> PResult<(Pos, Cow<'text, str>)> {


### PR DESCRIPTION
Hey, I noticed your implementation of `just-kdl` and really liked it, and also noticed that it could be entirely made to work without libstd, so, I decided to offer a PR for it.

You could probably make everything but the `dom` module also not use alloc, but since I noticed you had a few FIXMEs in there that still allocate, I decided to not mess with it for now.

I also added an optional `std` feature enabled by default in case you add anything that might need libstd in the future (like reading from files).